### PR TITLE
Update scrolling for api commands

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -30,7 +30,8 @@ const IndexPage: React.FC<IndexPageProps> = ({ inputRef }) => {
 
   React.useEffect(() => {
     if (inputRef.current) {
-      inputRef.current.focus();
+      inputRef.current.scrollIntoView();
+      inputRef.current.focus({preventScroll: true});
     }
   }, [history]);
 


### PR DESCRIPTION
When you run a command such as `help`, the terminal will automatically scroll down to the bottom of the output and to the next prompt. This doesn't happen for api commands such as `weather Miami`. This PR changes that and matches the api command behavior to the regular ones.