### PR TITLE
FIX abnormal spaces at start of ${readme}

### DIFF
--- a/src/utils/bin/api_commands.ts
+++ b/src/utils/bin/api_commands.ts
@@ -22,8 +22,7 @@ export const quote = async (args: string[]): Promise<string> => {
 
 export const readme = async (args: string[]): Promise<string> => {
   const readme = await getReadme();
-  return `Opening GitHub README...\n
-  ${readme}`;
+  return `Opening GitHub README...\n${readme}`;
 };
 
 export const weather = async (args: string[]): Promise<string> => {


### PR DESCRIPTION
Removed extra newline code
which causes abnormal line indentation at the start of ${readme} with extra 2 spaces