### PR TITLE
added feature to exclude commands based on user config

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ Learn more about Docker [here](https://docs.docker.com/get-started/overview/ 'he
     "github": // your handle
     "linkedin": // your handle
   },
+  "excluded_commands": [
+    // list of commands you would like to exclude
+    "command_1",
+    "command_n"
+  ],
   "email": // your email
   "ps1_hostname": "liveterm" // hostname in prompt
   "ps1_username": "visitor", // username in prompt

--- a/config.json
+++ b/config.json
@@ -16,6 +16,8 @@
     "paypal": "https://paypal.me/cveinnt",
     "patreon": "https://patreon.com/cveinnt"
   },
+  "excluded_commands": [
+  ],
   "colors": {
     "light": {
       "background": "#FBF1C9",

--- a/src/components/input.tsx
+++ b/src/components/input.tsx
@@ -3,6 +3,7 @@ import { commandExists } from '../utils/commandExists';
 import { shell } from '../utils/shell';
 import { handleTabCompletion } from '../utils/tabCompletion';
 import { Ps1 } from './Ps1';
+import { commandExclude } from '../utils/commandExclude';
 
 export const Input = ({
   inputRef,
@@ -89,7 +90,7 @@ export const Input = ({
         id="prompt"
         type="text"
         className={`bg-light-background dark:bg-dark-background focus:outline-none flex-grow ${
-          commandExists(command) || command === ''
+          (commandExists(command) || command === '') && !commandExclude(command)
             ? 'text-dark-green'
             : 'text-dark-red'
         }`}

--- a/src/utils/bin/commands.ts
+++ b/src/utils/bin/commands.ts
@@ -2,16 +2,21 @@
 
 import * as bin from './index';
 import config from '../../../config.json';
+import { commandExclude } from '../commandExclude';
 
 // Help
 export const help = async (args: string[]): Promise<string> => {
   const commands = Object.keys(bin).sort().join(', ');
   var c = '';
+  var included_count = 1;
   for (let i = 1; i <= Object.keys(bin).sort().length; i++) {
-    if (i % 7 === 0) {
-      c += Object.keys(bin).sort()[i - 1] + '\n';
-    } else {
-      c += Object.keys(bin).sort()[i - 1] + ' ';
+    if (!(commandExclude(Object.keys(bin).sort()[i-1]))){
+      if (included_count % 7 === 0) {
+        c += Object.keys(bin).sort()[i - 1] + '\n';
+      } else {
+        c += Object.keys(bin).sort()[i - 1] + ' ';
+      }
+      included_count++;
     }
   }
   return `Welcome! Here are all the available commands:

--- a/src/utils/commandExclude.ts
+++ b/src/utils/commandExclude.ts
@@ -1,0 +1,7 @@
+import config from '../../config.json';
+
+var exception_commands = [ 'banner' , 'help' ]
+
+export const commandExclude = (command: string) => {
+  return config.excluded_commands.includes(command) && !(exception_commands.includes(command))
+}

--- a/src/utils/shell.ts
+++ b/src/utils/shell.ts
@@ -1,5 +1,6 @@
 import React from 'react';
 import * as bin from './bin';
+import { commandExclude } from '../utils/commandExclude';
 
 export const shell = async (
   command: string,
@@ -14,7 +15,7 @@ export const shell = async (
     clearHistory();
   } else if (command === '') {
     setHistory('');
-  } else if (Object.keys(bin).indexOf(args[0]) === -1) {
+  } else if (Object.keys(bin).indexOf(args[0]) === -1 || commandExclude(args[0])) {
     setHistory(
       `shell: command not found: ${args[0]}. Try 'help' to get started.`,
     );


### PR DESCRIPTION
1. Added function to exclude commands. It basically checks if it is in the excluded_commands list in the config file.
2. Implemented the above function within:
    - input.tsx for command prompt colour
    - commands.ts so that it would not show the command when help is run
    - shell.ts so that the command does not run
3. Added a section to exclude the commands within the config file.
4. Added a section in README.md to help users with the feature.