### PR TITLE
echo command no longer returns html tags

### DIFF
--- a/src/utils/bin/commands.ts
+++ b/src/utils/bin/commands.ts
@@ -93,7 +93,8 @@ export const reddit = async (args: string[]): Promise<string> => {
 
 // Typical linux commands
 export const echo = async (args: string[]): Promise<string> => {
-  return args.join(' ');
+  return args.join(' ').replace( /<(?:(?:(?:(script|style|object|embed|applet|noframes|noscript|noembed)(?:\s+(?:"[\S\s]*?"|'[\S\s]*?'|(?:(?!\/>)[^>])?)+)?\s*>)[\S\s]*?<\/\1\s*(?=>))|(?:\/?[\w:]+\s*\/?)|(?:[\w:]+\s+(?:"[\S\s]*?"|'[\S\s]*?'|[^>]?)+\s*\/?)|\?[\S\s]*?\?|(?:!(?:(?:DOCTYPE[\S\s]*?)|(?:\[CDATA\[[\S\s]*?\]\])|(?:--[\S\s]*?--)|(?:ATTLIST[\S\s]*?)|(?:ENTITY[\S\s]*?)|(?:ELEMENT[\S\s]*?))))>/g,"");
+  //taken from: https://stackoverflow.com/questions/57398785/prevent-html-injections-with-javascript-typescript
 };
 
 export const whoami = async (args: string[]): Promise<string> => {


### PR DESCRIPTION
## Description
As stated in issue 25, you can insert html tags into the prompt and it will act as intended.

## Fix
The replace function was used to replace html tags with "". On linux, by default, it does not parse characters like < and would need to escape it. Example:

![2022-06-22-102033_804x217_scrot](https://user-images.githubusercontent.com/29141791/175054639-219d4204-e83f-4b96-ba12-2ae0d9ccc1b1.png)

For now it is a simple fix but as the other commands have cheesy responses, maybe instead of "removing" the tags and still outputting the text within them, respond with "Nice try!" ?

Closes: #25 